### PR TITLE
リソース情報更新（管理者操作）後、リソース表示画面にリダイレクトするように変更。

### DIFF
--- a/ckan/controllers/package.py
+++ b/ckan/controllers/package.py
@@ -398,9 +398,11 @@ class PackageController(base.BaseController):
         except NotAuthorized:
             abort(401, _('Unauthorized to read package %s') % id)
 
-        resource_id = request.params.get('id')
+        resource_id = request.params.get('resource_id')
         if resource_id:
-            resource_id = resource_id[0 : resource_id.rfind(":")]
+            pos_delimiter = resource_id.rfind(":")
+            if pos_delimiter > -1:
+                resource_id = resource_id[0 : resource_id.rfind(":")]
         else:
             resource_dict = c.pkg_dict.get('resources', [])
             if len(resource_dict):
@@ -620,7 +622,7 @@ class PackageController(base.BaseController):
                                           errors, error_summary)
             except NotAuthorized:
                 abort(401, _('Unauthorized to edit this resource'))
-            redirect(h.url_for(controller='package', action='resource_read',
+            redirect(h.url_for(controller='package', action='read',
                                id=id, resource_id=resource_id))
 
         context = {'model': model, 'session': model.Session,

--- a/ckan/templates/package/read.html
+++ b/ckan/templates/package/read.html
@@ -82,7 +82,7 @@
   {% block resource_list %}
     {% if pkg.resources %}
       <form method="get" data-module="select-switch">
-        <select id="resource_dropdown" name="id">
+        <select id="resource_dropdown" name="resource_id">
           <option value=""></option>
           {% for resource in pkg.resources %}
             <option value={{ resource.id}}:{{ resource.format.lower() or 'data' }} {% if res.id == resource.id %}selected="selected"{% endif %}>{{ h.resource_display_name(resource) | truncate(50) }}</option>


### PR DESCRIPTION
[変更前]
　現状のリソース詳細画面に遷移。
[変更後]
　リソース詳細画面は廃止になるので、リソース表示画面（改造を行っているページ）に遷移。
　遷移先では更新したリソース情報を選択して表示する。
