### PR TITLE
リソース詳細画面へのリンクをリソース一覧画面へのリンクに変更

### DIFF
--- a/ckan/templates/package/resource_edit_base.html
+++ b/ckan/templates/package/resource_edit_base.html
@@ -8,7 +8,7 @@
 {% block breadcrumb_content %}
   {{ super() }}
   {% if res %}
-    <li>{% link_for h.resource_display_name(res)|truncate(30), controller='package', action='resource_read', id=pkg.name, resource_id=res.id %}</li>
+    <li>{% link_for h.resource_display_name(res)|truncate(30), controller='package', action='read', id=pkg.name, resource_id=res.id %}</li>
     <li{% block breadcrumb_edit_selected %} class="active"{% endblock %}><a href="">{{ _('Edit') }}</a></li>
   {% endif %}
 {% endblock %}
@@ -16,7 +16,7 @@
 {% block content_action %}
   {% link_for _('All resources'), controller='package', action='resources', id=pkg.name, class_='btn', icon='arrow-left' %}
   {% if res %}
-    {% link_for _('View resource'), controller='package', action='resource_read', id=pkg.name, resource_id=res.id, class_='btn', icon='eye-open' %}
+    {% link_for _('View resource'), controller='package', action='read', id=pkg.name, resource_id=res.id, class_='btn', icon='eye-open' %}
   {% endif %}
 {% endblock %}
 

--- a/ckan/templates/package/view_edit_base.html
+++ b/ckan/templates/package/view_edit_base.html
@@ -8,7 +8,7 @@
 {% block content_action %}
   {% link_for _('All views'), controller='package', action='resource_views', id=pkg.name, resource_id=res.id, class_='btn', icon='arrow-left' %}
   {% if res %}
-    {% set url = h.url_for(controller='package', action='resource_read', id=pkg.name, resource_id=res.id) ~ '?view_id=' ~ resource_view.id %}
+    {% set url = h.url_for(controller='package', action='read', id=pkg.name, resource_id=res.id) ~ '&view_id=' ~ resource_view.id %}
     <a href="{{ url }}" class="btn"><i class="icon-eye-open"></i> {{ _('View view') }}</a>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
既存のリソース詳細画面へのリンクを、リソース一覧画面へのリンクに変更。
リソース一覧画面は、選択されたリソースを表示した状態で表示する。

[変更箇所]
・リソース編集画面のパンくずリストのリソース名クリックでの遷移
・リソース編集画面の「リソースの表示」ボタンクリックでの遷移
・ビュー編集画面の「ビューを閲覧」ボタンクリックでの遷移（指定したビューを選択した状態で表示する）
