### PR TITLE
アクティビティストリームのリソース名クリックのリンクをリソース詳細画面からリソース一覧画面に変更。

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -1145,7 +1145,7 @@ def resource_display_name(resource_dict):
 def resource_link(resource_dict, package_id):
     text = resource_display_name(resource_dict)
     url = url_for(controller='package',
-                  action='resource_read',
+                  action='read',
                   id=package_id,
                   resource_id=resource_dict['id'])
     return link_to(text, url)

--- a/ckan/templates/package/read.html
+++ b/ckan/templates/package/read.html
@@ -197,7 +197,8 @@
           </div>
         {% endblock %}
       {% endblock %}
-
+    {% else %}
+      {{ _("Resource not found")}}</li>
     {% endif %}
   {% endblock %}
 


### PR DESCRIPTION
削除されたリソースを選択した場合は、「リソースが見つかりません」のメッセージを表示する
